### PR TITLE
Fix url resolution for cover image

### DIFF
--- a/pypodcaster/__main__.py
+++ b/pypodcaster/__main__.py
@@ -15,6 +15,9 @@ from pypodcaster.channel import Channel
 
 __author__ = 'mantlepro'
 
+def get_version():
+    return
+
 VERSION = get_distribution('pypodcaster').version
 
 def main():
@@ -67,11 +70,12 @@ def main():
     # TODO: Is link url valid?
     # TODO: Does channel's cover image exist?
 
-    def validate(url):
-        validators.url(url)
-
     # remove trailing slashes to support either format in channel.yml
     options['podcast_url'] = trailing_slash(options['podcast_url'])
+
+    # determine whether cover image is a url
+    if not validators.url(options["image"]):
+        options['image'] = "%s/%s" % (options["podcast_url"], options["image"])
 
     if args.output:
         with open(args.output, 'w') as output_file:

--- a/pypodcaster/channel.py
+++ b/pypodcaster/channel.py
@@ -1,5 +1,7 @@
 import logging
 
+from pkg_resources import get_distribution
+
 from pypodcaster.item import Item
 
 __author__ = 'mantlepro'
@@ -47,7 +49,7 @@ class Channel:
         return template_xml.render(channel=self.options,
             items=self.items(self.options),
             last_build_date=strftime("%a, %d %b %Y %T %Z"),
-            generator="pypodcaster"
+            generator="pypodcaster " + get_distribution('pypodcaster').version
         )
 
 def add_files(source):

--- a/pypodcaster/item.py
+++ b/pypodcaster/item.py
@@ -70,10 +70,7 @@ def get_image_url(file_path, options, title, album):
 
     if not found:
         logging.debug("No episodic image found for %s. Using channel default image." % mp3file)
-        if validators.url(options["image"]):
-            image_url = options["image"]
-        else:
-            image_url = "%s/%s" % (options["podcast_url"], options["image"])
+        image_url = options["image"]
 
     return image_url
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name='pypodcaster',
-    version='1.1',
+    version='1.2',
     install_requires=requirements,
     packages=find_packages(),
     url='http://github.com/mantlepro/pypodcaster',


### PR DESCRIPTION
Prepend podcast_url to image listed in channel.yml if image is not a full url for both channel image and item images.